### PR TITLE
Add global font size toggle and refresh typography

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ graph TB
 - **狀態管理**：`src/stores/` 依功能拆分（auth、sheep、consultation、chat、prediction、iot、traceability、settings），皆附 Vitest 覆蓋。
 - **API 層**：`src/api/index.js` 統一錯誤處理、Gemini Header 注入、Multipart 上傳。
 - **視圖與測試**：每個頁面皆有對應測試 (`*.test.js` / `*.behavior.test.js`) 驗證路由守衛、表單驗證、Store 行為與 UI 呈現。
-- **UX**：Element Plus 排版、統一 loading/toast、AI Markdown 呈現、API Key 彈窗一次顯示。
+- **UX**：
+  - Element Plus 排版、統一 loading/toast、AI Markdown 呈現、API Key 彈窗一次顯示。
+  - 系統設定新增「字體大小」切換（預設／大字），同步調整 Element Plus 基準字級與全域 CSS 變數，方便熟齡牧場管理者以較大的字體操作系統。
 
 ## 5. AI 與機器學習能力
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -143,7 +143,9 @@ graph TB
 - **State Management**: Pinia stores under `src/stores/` wrap API clients with optimistic updates and error helpers (`auth`, `sheep`, `consultation`, `chat`, `prediction`, `iot`, `traceability`, `settings`). Each store ships with Vitest coverage.
 - **API Layer**: `src/api/index.js` exposes strongly-typed helpers, consistent error handling, and header propagation for Gemini API keys and multipart requests.
 - **Views**: Each route has a dedicated view under `src/views/` accompanied by unit/behaviour tests (e.g., `DashboardView.test.js`, `ConsultationView.behavior.test.js`). Components encapsulate tables, forms, and charts with Element Plus primitives.
-- **UX Considerations**: Responsive layout via Element Plus grid, consistent loading states, toast notifications for async flows, Markdown rendering for AI output, and modals for API key reveal.
+- **UX Considerations**:
+  - Responsive layout via Element Plus grid, consistent loading states, toast notifications for async flows, Markdown rendering for AI output, and modals for API key reveal.
+  - System Settings includes a persistent font size toggle (default vs. large) that updates the Element Plus base size and CSS variables so older farmers can switch to larger typography across the entire SPA.
 
 ## 5. AI & Machine Learning Capabilities
 

--- a/frontend/src/assets/styles/main.css
+++ b/frontend/src/assets/styles/main.css
@@ -1,22 +1,46 @@
 /* --- Global Styles --- */
-body {
+:root {
+    --app-font-scale: 1;
+    --app-line-height: 1.65;
+    --app-background: #f5f7fa;
+    --app-text-color: #334155;
+    --el-font-size-base: 1rem;
     font-family: 'Noto Sans TC', 'Roboto', sans-serif;
+    font-size: 100%;
+    color: var(--app-text-color);
+    background-color: var(--app-background);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+html {
+    min-height: 100%;
+}
+
+html[data-font-scale='large'] {
+    font-size: 112.5%;
+    --el-font-size-base: 1.125rem;
+}
+
+body {
     margin: 0;
-    color: #334155;
-    line-height: 1.65;
-    font-size: 15px;
+    min-height: 100vh;
+    font-family: 'Noto Sans TC', 'Roboto', sans-serif;
+    color: var(--app-text-color);
+    background-color: var(--app-background);
+    line-height: var(--app-line-height);
 }
 
 body .el-container {
-    height: 100%;
+    min-height: 100%;
 }
 
 .el-drawer__header {
     margin-bottom: 0 !important;
-    padding-bottom: 15px !important;
+    padding-bottom: 0.9375rem !important;
 }
 
-/* 
+/*
   為 Element Plus 的可排序表格標題添加鼠標指針
   並確保排序圖示可見
 */

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -7,6 +7,7 @@ import 'element-plus/dist/index.css'
 
 import App from './App.vue'
 import router from './router'
+import { useSettingsStore } from './stores/settings'
 
 // 導入我們自己的全域樣式
 import './assets/styles/main.css'
@@ -15,11 +16,16 @@ import './assets/styles/main.css'
 const app = createApp(App)
 
 // 註冊 Pinia 狀態管理
-app.use(createPinia())
+const pinia = createPinia()
+app.use(pinia)
 // 註冊 Vue Router
 app.use(router)
 // 註冊 Element Plus UI 庫
 app.use(ElementPlus)
+
+// 套用使用者偏好字體大小
+const settingsStore = useSettingsStore(pinia)
+settingsStore.ensureFontScaleApplied()
 
 // 將應用掛載到 index.html 中的 #app 元素上
 app.mount('#app')

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,79 +1,20 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
+a {
   font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-.card {
-  padding: 2em;
+  text-decoration: none;
 }
 
 #app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  min-height: 100vh;
 }

--- a/frontend/src/views/PredictionView.vue
+++ b/frontend/src/views/PredictionView.vue
@@ -516,22 +516,23 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
+
 .prediction-page {
-  padding: 20px;
+  padding: 1.25rem;
 }
 
 .page-title {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 24px;
+  gap: 0.5rem;
+  font-size: 1.5rem;
   font-weight: 600;
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
   color: #303133;
 }
 
 .card-header {
-  font-size: 16px;
+  font-size: 1.125rem;
   font-weight: 600;
   display: flex;
   justify-content: space-between;
@@ -539,13 +540,14 @@ onBeforeUnmount(() => {
 }
 
 .data-info {
-  font-size: 12px;
+  font-size: 0.875rem;
   color: #909399;
   font-weight: normal;
 }
 
+
 .sheep-selection-area {
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
 }
 
 .ear-tag-suggestion {
@@ -563,36 +565,39 @@ onBeforeUnmount(() => {
   font-size: 12px;
 }
 
+
 .results-card {
-  margin-top: 20px;
+  margin-top: 1.25rem;
 }
 
 .results-content {
-  min-height: 400px;
+  min-height: 25rem;
 }
+
 
 .chart-section {
   background: #f8f9fa;
-  padding: 20px;
-  border-radius: 8px;
+  padding: 1.25rem;
+  border-radius: 0.5rem;
 }
 
 .chart-container {
   width: 100%;
-  height: 400px;
-  margin: 20px 0;
+  height: 25rem;
+  margin: 1.25rem 0;
 }
 
 .key-metrics {
-  margin-top: 20px;
+  margin-top: 1.25rem;
 }
+
 
 .metric-card {
   background: white;
-  padding: 16px;
-  border-radius: 8px;
+  padding: 1rem;
+  border-radius: 0.5rem;
   text-align: center;
-  border: 2px solid #e4e7ed;
+  border: 0.125rem solid #e4e7ed;
 }
 
 .metric-card.status-good {
@@ -608,49 +613,50 @@ onBeforeUnmount(() => {
 }
 
 .metric-label {
-  font-size: 12px;
+  font-size: 0.875rem;
   color: #909399;
-  margin-bottom: 8px;
+  margin-bottom: 0.5rem;
 }
 
 .metric-value {
-  font-size: 18px;
+  font-size: 1.25rem;
   font-weight: 600;
   color: #303133;
 }
 
 .metric-subvalue {
-  margin-top: 6px;
-  font-size: 12px;
+  margin-top: 0.375rem;
+  font-size: 0.875rem;
   color: #606266;
 }
 
+
 .ai-report-section {
   background: #f0f9ff;
-  padding: 20px;
-  border-radius: 8px;
+  padding: 1.25rem;
+  border-radius: 0.5rem;
   height: 100%;
 }
 
 .ai-analysis-content {
-  margin-top: 16px;
+  margin-top: 1rem;
   line-height: 1.6;
 }
 
 .ai-analysis-content :deep(h3) {
   color: #409eff;
-  font-size: 16px;
-  margin: 16px 0 8px 0;
+  font-size: 1.125rem;
+  margin: 1rem 0 0.5rem 0;
 }
 
 .ai-analysis-content :deep(h4) {
   color: #606266;
-  font-size: 14px;
-  margin: 12px 0 6px 0;
+  font-size: 1rem;
+  margin: 0.75rem 0 0.375rem 0;
 }
 
 .ai-analysis-content :deep(p) {
-  margin: 8px 0;
+  margin: 0.5rem 0;
 }
 
 .ai-analysis-content :deep(strong) {
@@ -658,19 +664,19 @@ onBeforeUnmount(() => {
 }
 
 .ai-analysis-content :deep(ul) {
-  margin: 8px 0;
-  padding-left: 20px;
+  margin: 0.5rem 0;
+  padding-left: 1.25rem;
 }
 
 .ai-analysis-content :deep(li) {
-  margin: 4px 0;
+  margin: 0.25rem 0;
 }
 
 .prediction-warning {
-  margin-top: 16px;
+  margin-top: 1rem;
 }
 
 .policy-alert {
-  margin-top: 12px;
+  margin-top: 0.75rem;
 }
 </style>

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -5,6 +5,19 @@
       系統設定
     </h1>
 
+    <!-- 介面字體大小 -->
+    <el-card shadow="never" class="font-card">
+      <template #header><div class="card-header">介面字體大小</div></template>
+      <p>
+        針對視覺需求調整整體字級。預設值符合目前設計建議，選擇「大字體」可於各頁面放大文字，方便熟齡使用者閱讀。
+      </p>
+      <el-select v-model="fontScaleValue" class="font-scale-select" size="large">
+        <el-option :value="FONT_SCALE.DEFAULT" label="預設字級（建議）" />
+        <el-option :value="FONT_SCALE.LARGE" label="大字體" />
+      </el-select>
+      <p class="font-scale-hint">此設定會記住在瀏覽器中，重新整理或再次登入都會維持目前字級。</p>
+    </el-card>
+
     <!-- API 金鑰設定 -->
     <el-card shadow="never">
       <template #header><div class="card-header">Gemini API 金鑰設定</div></template>
@@ -77,7 +90,7 @@
 import { ref, reactive, onMounted, computed } from 'vue';
 import { Setting, Plus, Delete } from '@element-plus/icons-vue';
 import { ElMessage } from 'element-plus';
-import { useSettingsStore } from '../stores/settings';
+import { useSettingsStore, FONT_SCALE } from '../stores/settings';
 import api from '../api';
 
 const settingsStore = useSettingsStore();
@@ -93,6 +106,11 @@ const eventOptions = ref([]);
 const newEventType = ref('');
 const newDescriptions = reactive({});
 const activeCollapseItems = ref([]);
+
+const fontScaleValue = computed({
+  get: () => settingsStore.fontScale,
+  set: (value) => settingsStore.setFontScale(value),
+});
 
 const updateApiKeyStatus = () => {
   if (settingsStore.hasApiKey) {
@@ -200,6 +218,7 @@ const handleDeleteDescription = async (descId) => {
 
 onMounted(() => {
   apiKeyInput.value = settingsStore.apiKey;
+  settingsStore.ensureFontScaleApplied();
   updateApiKeyStatus();
   fetchEventOptions();
 });
@@ -208,55 +227,69 @@ onMounted(() => {
 <style scoped>
 .settings-page { animation: fadeIn 0.5s ease-out; }
 .page-title {
-  font-size: 1.8em; color: #1e3a8a; margin-top: 0;
-  margin-bottom: 20px; display: flex; align-items: center;
+  font-size: 1.75rem; color: #1e3a8a; margin-top: 0;
+  margin-bottom: 1.25rem; display: flex; align-items: center;
 }
 .page-title .el-icon { margin-right: 10px; }
-.card-header { font-size: 1.2em; font-weight: bold; }
-.el-card { margin-bottom: 20px; }
+.card-header { font-size: 1.125rem; font-weight: bold; }
+.el-card { margin-bottom: 1.5rem; }
 
 .api-key-status {
-  margin: 10px 0;
-  padding: 8px 12px;
+  margin: 0.625rem 0;
+  padding: 0.5rem 0.75rem;
   border-radius: 4px;
-  font-size: 0.9em;
+  font-size: 0.9375rem;
 }
 .api-key-status.info { background-color: #f4f4f5; color: #909399; }
 .api-key-status.success { background-color: #f0f9eb; color: #67c23a; }
 .api-key-status.error { background-color: #fef0f0; color: #f56c6c; }
 
+.font-card p {
+  margin-bottom: 0.5rem;
+}
+
+.font-scale-select {
+  max-width: 16rem;
+}
+
+.font-scale-hint {
+  margin-top: 0.75rem;
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
 .add-type-form {
   display: flex;
-  gap: 10px;
-  margin-bottom: 20px;
+  gap: 0.625rem;
+  margin-bottom: 1.25rem;
 }
 
 .collapse-title {
-  font-size: 1.1em;
+  font-size: 1.0625rem;
   font-weight: 500;
 }
 .title-tag {
-  margin-left: 10px;
+  margin-left: 0.625rem;
 }
 
 .description-list {
-  padding: 0 10px;
+  padding: 0 0.625rem;
 }
 .description-item {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 0;
+  padding: 0.5rem 0;
   border-bottom: 1px solid #f0f2f5;
 }
 .add-description-form {
   display: flex;
-  gap: 8px;
-  margin-top: 15px;
+  gap: 0.5rem;
+  margin-top: 0.9375rem;
 }
 .type-actions {
-  margin-top: 15px;
-  padding-top: 15px;
+  margin-top: 0.9375rem;
+  padding-top: 0.9375rem;
   border-top: 1px dashed #dcdfe6;
   text-align: right;
 }


### PR DESCRIPTION
## Summary of Changes
- add a persisted font scale preference to the settings store and apply it at app bootstrap so the html root updates Element Plus typography
- expose a font-size selector on the system settings page and refresh related styles (settings, prediction view, global CSS) to rely on rem units
- extend store/view tests and documentation to cover the new accessibility option

## Risk Assessment
- Low risk: frontend state and style updates only, covered by existing/unit tests

## Affected Modules
- frontend settings store and view
- global style sheets and prediction view styling
- project documentation

## Suggested Tests
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e691942ad0832aa2c653227e6f06a5